### PR TITLE
Adding user traits for better identification

### DIFF
--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -43,7 +43,8 @@ let currentPage;
 if (settings.track_users && currentUser && !userID) {
     api.container.lookup('store:main').find('user', currentUser.username).then((user) => {
         userID = ssoEnabled && settings.track_by_external_id ? user.external_id : user.id;
-        userTraits = ssoEnabled && settings.track_users_traits ? {name: user.name, email: user.email, nickname: user.username} : {};
+        userTraits = settings.track_users_traits ? {name: user.name, email: user.email, nickname: user.username} : {};
+
         analytics.identify(userID, userTraits);
     });
 }

--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -43,7 +43,8 @@ let currentPage;
 if (settings.track_users && currentUser && !userID) {
     api.container.lookup('store:main').find('user', currentUser.username).then((user) => {
         userID = ssoEnabled && settings.track_by_external_id ? user.external_id : user.id;
-        analytics.identify(userID);
+        userTraits = ssoEnabled && settings.track_users_traits ? {name: user.name, email: user.email, nickname: user.username} : {};
+        analytics.identify(userID, userTraits);
     });
 }
 

--- a/settings.yml
+++ b/settings.yml
@@ -4,6 +4,9 @@ segment_write_key:
 track_users:
   default: true
   description: "Call the Segment identify function when a user logs in or refreshes the site."
+track_users_traits:
+  default: true
+  description: "Add additional trait data to the user."
 track_by_external_id:
   default: false
   description: "For sites with SSO enabled, track users by their external_id instead of by their Discourse id."


### PR DESCRIPTION
I added a small line to the header code to track the users name, email and username when calling the `identify` method. That way it is possible to identify and track specific users throughout multiple platforms.

The additional collection of user traits can be deactivated via the settings.